### PR TITLE
Fix compile error in VRInventorySlot.cs

### DIFF
--- a/Source/Player/VRInventorySlot.cs
+++ b/Source/Player/VRInventorySlot.cs
@@ -58,12 +58,12 @@ public class VRInventorySlot : MonoBehaviour
     private void LateUpdate()
     {
         lineRenderer.positionCount = 4;
-        lineRenderer.SetPositions([
+        lineRenderer.SetPositions(new Vector3[] {
             transform.TransformPoint(new Vector3(-0.045f, heightOffset, -0.07f)),
             transform.TransformPoint(new Vector3(0.045f, heightOffset, -0.07f)),
             transform.TransformPoint(new Vector3(0.045f, heightOffset, 0.07f)),
             transform.TransformPoint(new Vector3(-0.045f, heightOffset, 0.07f))
-        ]);
+        });
         
         if (spot != null)
         {


### PR DESCRIPTION
When I compiled this app, I kept getting this error:

`The call is ambiguous between the following methods or properties: 'LineRenderer.SetPositions(Vector3[])' and 'LineRenderer.SetPositions(NativeArray<Vector3>)'`

The C# array syntax is only valid in newer versions of C# (from C# 12), and Unity does not yet support this syntax.

To fix it, I just added an initialization syntax so it can understand what it is and not fail the build.